### PR TITLE
Save comments to Datastore, add delete and other features

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -29,6 +29,12 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -20,7 +20,6 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.List;
 import java.util.ArrayList;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -16,7 +16,7 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.Query;
 import com.google.gson.Gson;
 import java.io.IOException;
@@ -55,17 +55,17 @@ public class DataServlet extends HttpServlet {
         String name = request.getParameter("name");
         String comment = request.getParameter("comment");
 
-        Entity taskEntity = new Entity("Task");
-        taskEntity.setProperty("name", name);
-        taskEntity.setProperty("comment", comment);
+        Entity commentEntity = new Entity("Comment");
+        commentEntity.setProperty("name", name);
+        commentEntity.setProperty("comment", comment);
 
-        datastore.put(taskEntity);
+        datastore.put(commentEntity);
         response.sendRedirect("/index.html");
     }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String input = request.getParameter("comment-number");
+        String input = request.getParameter("max-comments");
         int limit = 0;
         
         try {
@@ -75,20 +75,15 @@ public class DataServlet extends HttpServlet {
             return;
         }
 
-        Query query = new Query("Task");
-        PreparedQuery results = datastore.prepare(query);
+        Query query = new Query("Comment");
+        Iterable<Entity> results = datastore.prepare(query).asIterable(FetchOptions.Builder.withLimit(limit));
         
         ArrayList<Comment> allComments = new ArrayList<Comment>();
-        int index = 0;
-        for (Entity entity : results.asIterable()) {
-            if (index >= limit) {
-                break;
-            }
+        for (Entity entity : results) {
             String name = (String) entity.getProperty("name");
             String comment = (String) entity.getProperty("comment");
 
             allComments.add(new Comment(name, comment));
-            index++;
         }
         
         Gson gson = new Gson();

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -1,0 +1,42 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that deletes comments from Datastore. */
+@WebServlet("/delete-data")
+public class DeleteDataServlet extends HttpServlet {
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Query query = new Query("Task");
+        PreparedQuery results = datastore.prepare(query);
+        
+        for (Entity entity : results.asIterable()) {
+            datastore.delete(entity.getKey());
+        }
+
+        response.sendRedirect("/index.html");
+    }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -30,7 +30,7 @@ public class DeleteDataServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-        Query query = new Query("Task");
+        Query query = new Query("Comment");
         PreparedQuery results = datastore.prepare(query);
         
         for (Entity entity : results.asIterable()) {

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -140,7 +140,7 @@
                 <h1>Comments</h1>
                 <form>
                     <h3>Comments to Show: 
-                        <select name="comment-number" id="comment-number">
+                        <select name="max-comments" id="max-comments">
                             <option value="5">5</option>
                             <option value="10">10</option>
                             <option value="20">20</option>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -9,7 +9,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap" rel="stylesheet">
   </head>
 
-  <body onload="displayComment()">
+  <!-- <body> -->
+  <body onload="displayComments()">
+
     <div id="page-container">
         <!-- The left section of the webpage, containing the diamond. -->
         <div>
@@ -137,8 +139,22 @@
                 <br>
                 <br>
                 <h1>Comments</h1>
+                <form>
+                    <h3>Comments to Show: 
+                        <select name="comment-number" id="comment-number">
+                            <option value="5">5</option>
+                            <option value="10">10</option>
+                            <option value="20">20</option>
+                            <option value="50">50</option>
+                        </select>
+                    </h3>
+                    <!-- <input class="button" type="submit"/> -->
+                    <input onclick="displayComments()" class="button" type="submit"/>
+                </form>
                 <hr>
                 <div id="comment-container"></div>
+                <br>
+                <button id="delete-button" onclick="deleteComments()">Delete All Comments</button>
             </div>
         </div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -9,7 +9,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap" rel="stylesheet">
   </head>
 
-  <!-- <body> -->
   <body onload="displayComments()">
 
     <div id="page-container">
@@ -148,7 +147,6 @@
                             <option value="50">50</option>
                         </select>
                     </h3>
-                    <!-- <input class="button" type="submit"/> -->
                     <input onclick="displayComments()" class="button" type="submit"/>
                 </form>
                 <hr>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -115,9 +115,9 @@ function diamondDescriptionUpdate(hitCount) {
 */
 function displayComments() {
     const urlParams = new URLSearchParams(window.location.search);
-    const query = urlParams.get('comment-number') || 5;
+    const query = urlParams.get('max-comments') || 5;
     
-    fetch('/data?comment-number=' + query).then(response => response.json()).then((commentData) => {
+    fetch('/data?max-comments=' + query).then(response => response.json()).then((commentData) => {
         const commentHTML = document.getElementById('comment-container');
         var newHTML = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -111,10 +111,13 @@ function diamondDescriptionUpdate(hitCount) {
 }
 
 /**
-* Temporary function that formats and displays comment on page. This does not yet save comments.
+* Function that recieves the indicated number of comments from datastore and displays the result after formatting.
 */
-function displayComment() {
-    fetch('/data').then(response => response.json()).then((commentData) => {
+function displayComments() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const query = urlParams.get('comment-number') || 5;
+    
+    fetch('/data?comment-number=' + query).then(response => response.json()).then((commentData) => {
         const commentHTML = document.getElementById('comment-container');
         var newHTML = "";
 
@@ -129,4 +132,12 @@ function displayComment() {
 
         commentHTML.innerHTML = newHTML;
     });
+}
+
+/**
+* Function that deletes all comments stored in Datastore.
+*/
+async function deleteComments() {
+    await fetch('/delete-data');
+    displayComments();
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -159,6 +159,27 @@ textarea {
     outline:none;
 }
 
+#comment-number {
+    color: #363333;
+    background-color: white;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    font-family: 'Josefin Sans', sans-serif;
+    padding: 5px;
+}
+
+#comment-number:hover {
+    cursor:cell;
+}
+
+#comment-number:active {
+    cursor: crosshair;
+    background-color: #ffb3ba;
+    text-decoration: none;
+    border: 0;
+    outline:none;
+}
+
 .comment-style-1 {
     margin: 0px;
     color:#8e8e8e;
@@ -166,4 +187,17 @@ textarea {
 
 .comment-style-2 {
     margin: 0px;
+}
+
+#delete-button {
+    color: #363333;
+    background-color: #ffb3ba;
+    border: 0;
+    border-radius: 0.5rem;
+    font-family: 'Josefin Sans', sans-serif;
+    padding: 10px;
+}
+
+.button:hover {
+    cursor: cell;
 }


### PR DESCRIPTION
###  Save comments to Datastore, add delete feature, limit the amount of comments loaded at once.

**Changes**
These are the rest of the changes for the comment tutorial.
- Save comments to Datastore
- Add a delete feature that deletes all comments
- Add a form to limit the number of comments shown by a predetermined set of amounts

This is what I have so far. It works _mostly_ as intended, but it feels kind of sloppy. I tried to clean it up, but I probably missed some stuff. Please let me know even the most nit-picky of changes I can make. 

**Questions**
I have been looking for a while, but there is a minor issue that I have not been able to fix. When the page deletes a large amount of comments at once, the page will sometimes refresh and display the comments before they can all be deleted. I tried a number of different await/async things in the javascript file, as well as refreshing after the delete loop in the DeleteDataServlet, but nothing has fixed this.

These comments do eventually get deleted, and just refreshing the page again shows the correct result. Do you have any advice, or can you see where things are going wrong?

**Attached**
- An image showing the added features as they would appear on the site.

![Screenshot 2020-06-16 at 8 10 10 PM](https://user-images.githubusercontent.com/39443120/84843517-b79ffb80-b00d-11ea-8834-2cfed2d6abf4.png)
